### PR TITLE
Use Node LTS and bump cimg version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,26 +2,26 @@ version: 2
 jobs:
   build_push:
     docker:
-    - image: cimg/base:stable-20.04
+      - image: cimg/base:current
     steps:
-    - checkout
-    - setup_remote_docker
-    - run:
-        name: Login to Docker hub
-        command: docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
-    - run:
-        name: Build image
-        command: make build
-    - run:
-        name: Push image
-        command: make push
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Login to Docker hub
+          command: docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+      - run:
+          name: Build image
+          command: make build
+      - run:
+          name: Push image
+          command: make push
 
 workflows:
   version: 2
   build_push:
     jobs:
-    - build_push:
-        filters:
-          branches:
-            only:
-            - master
+      - build_push:
+          filters:
+            branches:
+              only:
+                - master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/node:20.11.0
+FROM cimg/node:lts
 
 ARG GOOGLE_SDK_VERSION=428.0.0-0
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 REPO=fyndiq
 NAME=circleci-node-gcloudsdk
-TAG=node20.11.0-gcloudsdk321.0.0-v1
+TAG=node-lts-gcloudsdk428.0.0-v1
 
 build:
 	docker build -t $(REPO)/$(NAME):$(TAG) .


### PR DESCRIPTION
We're bumping the SSR and BFFS to use `node/lts` everywhere.