### PR TITLE
Upgrade google cloud sdk and prepare to release an lts node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/node:22.19
+FROM cimg/node:lts
 
 ARG GOOGLE_SDK_VERSION=538.0.0-0
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM cimg/node:lts
+FROM cimg/node:22.19
 
-ARG GOOGLE_SDK_VERSION=428.0.0-0
+ARG GOOGLE_SDK_VERSION=538.0.0-0
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     sudo apt-get install -y apt-transport-https ca-certificates gnupg && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
-    sudo apt-get update && sudo apt-get install -y google-cloud-sdk=$GOOGLE_SDK_VERSION && \
-    sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
+    sudo apt-get update && sudo apt-get install -y google-cloud-cli=$GOOGLE_SDK_VERSION && \
+    sudo apt-get install google-cloud-cli-gke-gcloud-auth-plugin
 
 ARG SKAFFOLD_VERSION=v1.17.2
 RUN sudo curl -Lo skaffold https://github.com/GoogleContainerTools/skaffold/releases/download/$SKAFFOLD_VERSION/skaffold-linux-amd64 && \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 REPO=fyndiq
 NAME=circleci-node-gcloudsdk
-TAG=node-lts-gcloudsdk428.0.0-v1
+TAG=node-22.19-gcloudsdk538.0.0-v1
 
 build:
 	docker build -t $(REPO)/$(NAME):$(TAG) .

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 REPO=fyndiq
 NAME=circleci-node-gcloudsdk
-TAG=node-22.19-gcloudsdk538.0.0-v1
+TAG=node-lts-gcloudsdk538.0.0-v1
 
 build:
 	docker build -t $(REPO)/$(NAME):$(TAG) .

--- a/README.md
+++ b/README.md
@@ -1,5 +1,100 @@
 # CircleCI Node Google Cloud SDK
-Docker image that extends the `cimg/node` image with Google's Cloud SDK.
 
-See [Dockerhub](https://hub.docker.com/r/fyndiq/circleci-node-gcloudsdk/) for
-available tags
+Docker image that extends the `cimg/node` image with Google's Cloud SDK and additional tools for CI/CD pipelines.
+
+## Current Version
+
+- **Node.js**: 22.19.0 (LTS)
+- **Google Cloud SDK**: 538.0.0
+- **Additional Tools**: kubectl, Helm (v3.4.2), Skaffold (v1.17.2), jq
+
+## Quick Start
+
+```bash
+# Use in your CircleCI config
+docker: fyndiq/circleci-node-gcloudsdk:node-22.19-gcloudsdk538.0.0-v1
+```
+
+## Building and Testing
+
+### Build the Image
+
+```bash
+make build
+```
+
+### Test the Image
+
+Run the comprehensive test suite to verify all tools work correctly:
+
+```bash
+./test-image.sh
+```
+
+The test script will verify:
+
+- ✅ Node.js version and npm
+- ✅ Google Cloud SDK functionality
+- ✅ kubectl, Helm, Skaffold, and jq tools
+- ✅ CircleCI user setup and sudo access
+
+### Push to Registry
+
+```bash
+make push
+```
+
+## Updating Versions
+
+### Update Node.js Version
+
+1. Check available `cimg/node` tags at [CircleCI Node Images](https://circleci.com/developer/images/image/cimg/node)
+2. Update the `FROM` line in `Dockerfile`:
+
+   ```dockerfile
+   FROM cimg/node:22.19  # Change to desired version
+   ```
+
+3. Update the tag in `Makefile`:
+
+   ```makefile
+   TAG=node-22.19-gcloudsdk538.0.0-v1  # Update Node.js version
+   ```
+
+4. Update the test script tag in `test-image.sh`
+5. Test the changes: `./test-image.sh`
+
+### Update Google Cloud SDK Version
+
+1. Find latest version:
+
+   ```bash
+   curl -s https://packages.cloud.google.com/apt/dists/cloud-sdk/main/binary-all/Packages | grep "Version:" | sort -V | tail -5
+   ```
+
+2. Update `GOOGLE_SDK_VERSION` in `Dockerfile`:
+
+   ```dockerfile
+   ARG GOOGLE_SDK_VERSION=538.0.0-0  # Change to desired version
+   ```
+
+3. Update the tag in `Makefile` and `test-image.sh`
+4. Test the changes: `./test-image.sh`
+
+### Update Other Tools
+
+Edit the respective `ARG` variables in the `Dockerfile`:
+
+- `SKAFFOLD_VERSION` for Skaffold
+- `HELM_VERSION` for Helm
+
+## Available Tags
+
+See [Dockerhub](https://hub.docker.com/r/fyndiq/circleci-node-gcloudsdk/) for all available tags.
+
+## Contributing
+
+1. Make your changes
+2. Run tests: `./test-image.sh`
+3. Ensure all tests pass before pushing
+4. Update this README if changing versions or adding features

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Docker image that extends the `cimg/node` image with Google's Cloud SDK and addi
 
 ## Current Version
 
-- **Node.js**: 22.19.0 (LTS)
+- **Node.js**: LTS (automatically tracks latest LTS - currently 22.19.0)
 - **Google Cloud SDK**: 538.0.0
 - **Additional Tools**: kubectl, Helm (v3.4.2), Skaffold (v1.17.2), jq
 
@@ -12,7 +12,7 @@ Docker image that extends the `cimg/node` image with Google's Cloud SDK and addi
 
 ```bash
 # Use in your CircleCI config
-docker: fyndiq/circleci-node-gcloudsdk:node-22.19-gcloudsdk538.0.0-v1
+docker: fyndiq/circleci-node-gcloudsdk:node-lts-gcloudsdk538.0.0-v1
 ```
 
 ## Building and Testing
@@ -52,13 +52,13 @@ make push
 2. Update the `FROM` line in `Dockerfile`:
 
    ```dockerfile
-   FROM cimg/node:22.19  # Change to desired version
+   FROM cimg/node:lts  # Use LTS for automatic updates, or specific version like 22.19
    ```
 
 3. Update the tag in `Makefile`:
 
    ```makefile
-   TAG=node-22.19-gcloudsdk538.0.0-v1  # Update Node.js version
+   TAG=node-lts-gcloudsdk538.0.0-v1  # Use lts or specific version number
    ```
 
 4. Update the test script tag in `test-image.sh`

--- a/test-image.sh
+++ b/test-image.sh
@@ -3,7 +3,7 @@
 # Test script to validate the Node.js 22 Docker image functionality
 set -e
 
-IMAGE_TAG="fyndiq/circleci-node-gcloudsdk:node-22.19-gcloudsdk538.0.0-v1"
+IMAGE_TAG="fyndiq/circleci-node-gcloudsdk:node-lts-gcloudsdk538.0.0-v1"
 
 echo "🧪 Testing Docker image: $IMAGE_TAG"
 echo "=================================="

--- a/test-image.sh
+++ b/test-image.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Test script to validate the Node.js 22 Docker image functionality
+set -e
+
+IMAGE_TAG="fyndiq/circleci-node-gcloudsdk:node-22.19-gcloudsdk538.0.0-v1"
+
+echo "🧪 Testing Docker image: $IMAGE_TAG"
+echo "=================================="
+
+# Step 1: Build the image
+echo "1️⃣  Building Docker image..."
+make build
+
+# Step 2: Test Node.js version
+echo "2️⃣  Testing Node.js version..."
+NODE_VERSION=$(docker run --rm $IMAGE_TAG node --version)
+echo "✅ Node.js version: $NODE_VERSION"
+
+# Verify it's Node.js 22
+if [[ $NODE_VERSION == v22.* ]]; then
+    echo "✅ Node.js 22.x confirmed"
+else
+    echo "❌ Expected Node.js 22.x, got: $NODE_VERSION"
+    exit 1
+fi
+
+# Step 3: Test npm
+echo "3️⃣  Testing npm..."
+NPM_VERSION=$(docker run --rm $IMAGE_TAG npm --version)
+echo "✅ npm version: $NPM_VERSION"
+
+# Step 4: Test Google Cloud SDK
+echo "4️⃣  Testing Google Cloud SDK..."
+GCLOUD_VERSION=$(docker run --rm $IMAGE_TAG gcloud --version | head -1)
+echo "✅ Google Cloud SDK version: $GCLOUD_VERSION"
+
+# Step 5: Test kubectl
+echo "5️⃣  Testing kubectl..."
+KUBECTL_VERSION=$(docker run --rm $IMAGE_TAG kubectl version --client --output=yaml | grep gitVersion || echo "kubectl installed")
+echo "✅ kubectl: $KUBECTL_VERSION"
+
+# Step 6: Test helm
+echo "6️⃣  Testing Helm..."
+HELM_VERSION=$(docker run --rm $IMAGE_TAG helm version --short --client)
+echo "✅ Helm version: $HELM_VERSION"
+
+# Step 7: Test skaffold
+echo "7️⃣  Testing Skaffold..."
+SKAFFOLD_VERSION=$(docker run --rm $IMAGE_TAG skaffold version)
+echo "✅ Skaffold version: $SKAFFOLD_VERSION"
+
+# Step 8: Test jq
+echo "8️⃣  Testing jq..."
+JQ_VERSION=$(docker run --rm $IMAGE_TAG jq --version)
+echo "✅ jq version: $JQ_VERSION"
+
+# Step 9: Test user setup
+echo "9️⃣  Testing user setup..."
+USER_INFO=$(docker run --rm $IMAGE_TAG whoami)
+echo "✅ Running as user: $USER_INFO"
+
+if [[ $USER_INFO == "circleci" ]]; then
+    echo "✅ CircleCI user setup confirmed"
+else
+    echo "❌ Expected user 'circleci', got: $USER_INFO"
+    exit 1
+fi
+
+# Step 10: Test sudo access
+echo "🔟 Testing sudo access..."
+docker run --rm $IMAGE_TAG sudo echo "Sudo access works" > /dev/null
+echo "✅ Sudo access confirmed"
+
+echo ""
+echo "🎉 All tests passed! The Docker image is ready for use."
+echo "=================================="
+echo "Node.js version: $NODE_VERSION"
+echo "Google Cloud SDK: $GCLOUD_VERSION"
+echo "Running as: $USER_INFO"
+echo ""
+echo "To use this image:"
+echo "  docker run -it --rm $IMAGE_TAG"
+echo ""
+echo "To push to registry:"
+echo "  make push"


### PR DESCRIPTION
## Description
Upgrade gcloud to latest compatible version with lts.
And after the approval, I'm gonna merge then `make build` and `make push` to get the lts version of node for our applications (SSR and BFFs repos)