### PR TITLE
fix: update Makefile and README to do amd64 architecture builds and enhance testing instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ NAME=circleci-node-gcloudsdk
 TAG=node-lts-gcloudsdk538.0.0-v1
 
 build:
-	docker buildx build --platform linux/amd64 -t $(REPO)/$(NAME):$(TAG) .
+	docker buildx build --platform linux/amd64 -t $(REPO)/$(NAME):$(TAG) --load .
 	docker tag $(REPO)/$(NAME):$(TAG) $(REPO)/$(NAME):latest
 
 build-local:

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ NAME=circleci-node-gcloudsdk
 TAG=node-lts-gcloudsdk538.0.0-v1
 
 build:
+	docker buildx build --platform linux/amd64 -t $(REPO)/$(NAME):$(TAG) .
+	docker tag $(REPO)/$(NAME):$(TAG) $(REPO)/$(NAME):latest
+
+build-local:
 	docker build -t $(REPO)/$(NAME):$(TAG) .
 	docker tag $(REPO)/$(NAME):$(TAG) $(REPO)/$(NAME):latest
 
@@ -10,5 +14,4 @@ run:
 	docker run -it --rm $(REPO)/$(NAME):$(TAG)
 
 push:
-	docker push $(REPO)/$(NAME):$(TAG)
-	docker push $(REPO)/$(NAME):latest
+	docker buildx build --platform linux/amd64 -t $(REPO)/$(NAME):$(TAG) -t $(REPO)/$(NAME):latest . --push

--- a/README.md
+++ b/README.md
@@ -17,10 +17,18 @@ docker: fyndiq/circleci-node-gcloudsdk:node-lts-gcloudsdk538.0.0-v1
 
 ## Building and Testing
 
+### Architecture Requirements
+
+**Important**: This image must be built for `linux/amd64` architecture to be compatible with CircleCI runners.
+
 ### Build the Image
 
 ```bash
+# Build for production (amd64 - CircleCI compatible)
 make build
+
+# Build for local testing (native architecture)
+make build-local
 ```
 
 ### Test the Image
@@ -41,8 +49,11 @@ The test script will verify:
 ### Push to Registry
 
 ```bash
+# Builds for amd64 and pushes directly
 make push
 ```
+
+**Note**: `make push` automatically builds for `linux/amd64` and pushes to ensure CircleCI compatibility.
 
 ## Updating Versions
 
@@ -87,6 +98,27 @@ Edit the respective `ARG` variables in the `Dockerfile`:
 
 - `SKAFFOLD_VERSION` for Skaffold
 - `HELM_VERSION` for Helm
+
+## Troubleshooting
+
+### Common Issues
+
+**Architecture Issues in CircleCI**
+- **Error**: "found arm64 but need [amd64 i386 386]"
+- **Solution**: Rebuild with `make push` (builds for amd64 automatically)
+- **Cause**: Image was built on Apple Silicon (arm64) but CircleCI needs amd64
+
+**Google Cloud SDK Installation Fails**
+- Ensure you're using the correct package name (`google-cloud-cli` vs `google-cloud-sdk`)
+- Check version compatibility with the base Node.js image
+
+**Node.js Version Mismatch**
+- Verify the `cimg/node` tag exists: `docker pull cimg/node:VERSION`
+- Use `docker run --rm cimg/node:VERSION node --version` to check exact version
+
+**Build Performance**
+- Docker layers are cached for faster rebuilds
+- Use `docker system prune` if builds become slow
 
 ## Available Tags
 

--- a/test-image.sh
+++ b/test-image.sh
@@ -10,6 +10,7 @@ echo "=================================="
 
 # Step 1: Build the image
 echo "1️⃣  Building Docker image..."
+echo "ℹ️  Note: Building for amd64 architecture (CircleCI compatible)"
 make build
 
 # Step 2: Test Node.js version
@@ -71,6 +72,16 @@ fi
 echo "🔟 Testing sudo access..."
 docker run --rm $IMAGE_TAG sudo echo "Sudo access works" > /dev/null
 echo "✅ Sudo access confirmed"
+
+# Step 11: Check image architecture
+echo "1️⃣1️⃣ Checking image architecture..."
+ARCH_INFO=$(docker inspect $IMAGE_TAG --format='{{.Architecture}}')
+echo "✅ Image architecture: $ARCH_INFO"
+if [[ $ARCH_INFO == "amd64" ]]; then
+    echo "✅ Architecture is amd64 (CircleCI compatible)"
+else
+    echo "⚠️  Warning: Architecture is $ARCH_INFO (may not work in CircleCI)"
+fi
 
 echo ""
 echo "🎉 All tests passed! The Docker image is ready for use."


### PR DESCRIPTION
## Description

The build target has to amd64, so I added specific instructions for that. Otherwise CircleCI is not gonna be happy about it