### PR TITLE
fix: pin Node.js version to 22.19 in Dockerfile and update README for compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/node:lts
+FROM cimg/node:22.19
 
 ARG GOOGLE_SDK_VERSION=538.0.0-0
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Docker image that extends the `cimg/node` image with Google's Cloud SDK and addi
 
 ## Current Version
 
-- **Node.js**: LTS (automatically tracks latest LTS - currently 22.19.0)
+- **Node.js**: 22.19 (pinned for compatibility)
 - **Google Cloud SDK**: 538.0.0
 - **Additional Tools**: kubectl, Helm (v3.4.2), Skaffold (v1.17.2), jq
 
@@ -63,7 +63,7 @@ make push
 2. Update the `FROM` line in `Dockerfile`:
 
    ```dockerfile
-   FROM cimg/node:lts  # Use LTS for automatic updates, or specific version like 22.19
+   FROM cimg/node:22.19  # Pinned to specific version for compatibility
    ```
 
 3. Update the tag in `Makefile`:


### PR DESCRIPTION
setting nodejs to 22.19.0 so it satisfies the application layer fixed version